### PR TITLE
Adding parameters to change confd/vhost/mod dir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,10 @@ class apache (
   $purge_configs        = true,
   $serveradmin          = 'root@localhost',
   $sendfile             = false,
-  $error_documents      = false
+  $error_documents      = false,
+  $confd_dir            = $apache::params::confd_dir,
+  $vhost_dir            = $apache::params::vhost_dir,
+  $mod_dir              = $apache::params::mod_dir
 ) inherits apache::params {
 
   package { 'httpd':
@@ -52,7 +55,7 @@ class apache (
     subscribe => Package['httpd'],
   }
 
-  file { $apache::params::confd_dir:
+  file { $apache::confd_dir:
     ensure  => directory,
     recurse => true,
     purge   => $purge_configs,
@@ -60,20 +63,24 @@ class apache (
     require => Package['httpd'],
   }
 
-  file { $apache::params::mod_dir:
-    ensure  => directory,
-    recurse => true,
-    purge   => $purge_configs,
-    notify  => Service['httpd'],
-    require => Package['httpd'],
+  if ! defined(File[$apache::mod_dir]) {
+    file { $apache::mod_dir:
+      ensure  => directory,
+      recurse => true,
+      purge   => $purge_configs,
+      notify  => Service['httpd'],
+      require => Package['httpd'],
+    }
   }
 
-  file { $apache::params::vhost_dir:
-    ensure  => directory,
-    recurse => true,
-    purge   => $purge_configs,
-    notify  => Service['httpd'],
-    require => Package['httpd'],
+  if ! defined(File[$apache::vhost_dir]) {
+    file { $apache::vhost_dir:
+      ensure  => directory,
+      recurse => true,
+      purge   => $purge_configs,
+      notify  => Service['httpd'],
+      require => Package['httpd'],
+    }
   }
 
   concat { $ports_file:

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -2,11 +2,14 @@ define apache::mod (
   $package = undef,
   $lib = undef
 ) {
+  if ! defined(Class['apache']) {
+    fail("You must include the apache base class before using any apache defined resources")
+  }
+
   $mod = $name
-  include apache::params
   #include apache #This creates duplicate resources in rspec-puppet
   $lib_path = $apache::params::lib_path
-  $mod_dir = $apache::params::mod_dir
+  $mod_dir = $apache::mod_dir
 
   # Determine if we have special lib
   $mod_libs = $apache::params::mod_libs

--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -5,8 +5,9 @@ class apache::mod::alias {
   }
   apache::mod { 'alias': }
   # Template uses $icons_path
-  file { "${apache::params::mod_dir}/alias.conf":
+  file { 'alias.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/alias.conf",
     content => template('apache/mod/alias.conf.erb'),
   }
 }

--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -1,8 +1,9 @@
 class apache::mod::autoindex {
   apache::mod { 'autoindex': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/autoindex.conf":
+  file { 'autoindex.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/autoindex.conf",
     content => template('apache/mod/autoindex.conf.erb'),
   }
 }

--- a/manifests/mod/cgid.pp
+++ b/manifests/mod/cgid.pp
@@ -4,8 +4,9 @@ class apache::mod::cgid {
   }
   apache::mod { 'cgid': }
   # Template uses $cgisock_path
-  file { "${apache::params::mod_dir}/cgid.conf":
+  file { 'cgid.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/cgid.conf",
     content => template('apache/mod/cgid.conf.erb'),
   }
 }

--- a/manifests/mod/dav_fs.pp
+++ b/manifests/mod/dav_fs.pp
@@ -8,8 +8,9 @@ class apache::mod::dav_fs {
   apache::mod { 'dav_fs': }
 
   # Template uses: $dav_lock
-  file { "${apache::params::mod_dir}/dav_fs.conf":
+  file { 'dav_fs.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/dav_fs.conf",
     content => template('apache/mod/php.conf.erb'),
   }
 }

--- a/manifests/mod/deflate.pp
+++ b/manifests/mod/deflate.pp
@@ -1,8 +1,9 @@
 class apache::mod::deflate {
   apache::mod { 'deflate': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/deflate.conf":
+  file { 'deflate.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/deflate.conf",
     content => template('apache/mod/deflate.conf.erb'),
   }
 }

--- a/manifests/mod/dir.pp
+++ b/manifests/mod/dir.pp
@@ -4,8 +4,9 @@ class apache::mod::dir (
   apache::mod { 'dir': }
 
   # Template uses no variables
-  file { "${apache::params::mod_dir}/dir.conf":
+  file { 'dir.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/dir.conf",
     content => template('apache/mod/dir.conf.erb'),
   }
 }

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -8,8 +8,9 @@ class apache::mod::disk_cache {
 
   apache::mod { 'disk_cache': }
   # Template uses $cache_proxy
-  file { "${apache::params::mod_dir}/disk_cache.conf":
+  file { 'disk_cache.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/disk_cache.conf",
     content => template('apache/mod/disk_cache.conf.erb'),
   }
 }

--- a/manifests/mod/info.pp
+++ b/manifests/mod/info.pp
@@ -1,8 +1,9 @@
 class apache::mod::info {
   apache::mod { 'info': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/info.conf":
+  file { 'info.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/info.conf",
     content => template('apache/mod/info.conf.erb'),
   }
 }

--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -1,8 +1,9 @@
 class apache::mod::ldap {
   apache::mod { 'ldap': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/ldap.conf":
+  file { 'ldap.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/ldap.conf",
     content => template('apache/mod/ldap.conf.erb'),
   }
 }

--- a/manifests/mod/mime.pp
+++ b/manifests/mod/mime.pp
@@ -1,8 +1,9 @@
 class apache::mod::mime {
   apache::mod { 'mime': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/mime.conf":
+  file { 'mime.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/mime.conf",
     content => template('apache/mod/mime.conf.erb'),
   }
 }

--- a/manifests/mod/mime_magic.pp
+++ b/manifests/mod/mime_magic.pp
@@ -1,8 +1,9 @@
 class apache::mod::mime_magic {
   apache::mod { 'mime_magic': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/mime_magic.conf":
+  file { 'mime_magic.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/mime_magic.conf",
     content => template('apache/mod/mime_magic.conf.erb'),
   }
 }

--- a/manifests/mod/mpm_event.pp
+++ b/manifests/mod/mpm_event.pp
@@ -1,7 +1,8 @@
 class apache::mod::mpm_event {
   # Template uses no variables
-  file { "${apache::params::mod_dir}/mpm_event.conf":
+  file { 'mpm_event.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/mpm_event.conf",
     content => template('apache/mod/mpm_event.conf.erb'),
   }
 }

--- a/manifests/mod/negotiation.pp
+++ b/manifests/mod/negotiation.pp
@@ -1,8 +1,9 @@
 class apache::mod::negotiation {
   apache::mod { 'negotiation': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/negotiation.conf":
+  file { 'negotiation.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/negotiation.conf",
     content => template('apache/mod/negotiation.conf.erb'),
   }
 }

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -5,8 +5,9 @@ class apache::mod::passenger (
 ) {
   apache::mod { 'passenger': }
   # Template uses $passenger_root, $passenger_ruby, $passenger_max_pool_size
-  file { "${apache::params::mod_dir}/passenger.conf":
+  file { 'passenger.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/passenger.conf",
     content => template('apache/mod/passenger.conf.erb'),
   }
 }

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -1,7 +1,8 @@
 class apache::mod::php {
   apache::mod { 'php5': }
-  file { "${apache::params::mod_dir}/php.conf":
+  file { 'php.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/php.conf",
     content => template('apache/mod/php.conf.erb'),
   }
 }

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -3,8 +3,9 @@ class apache::mod::proxy (
 ) {
   apache::mod { 'proxy': }
   # Template uses $proxy_requests
-  file { "${apache::params::mod_dir}/proxy.conf":
+  file { 'proxy.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/proxy.conf",
     content => template('apache/mod/proxy.conf.erb'),
   }
 }

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -3,8 +3,9 @@ class apache::mod::proxy_html {
   Class['apache::mod::proxy_http'] -> Class['apache::mod::proxy_html']
   apache::mod { 'proxy_html': }
   # proxy_html uses libxml2 so we need to load this .so
-  file { "${apache::params::mod_dir}/libxml2.load":
+  file { 'libxml2.load':
     ensure  => present,
+    path    => "${apache::mod_dir}/libxml2.conf",
     content => "LoadFile /usr/lib/libxml2.so.2\n",
   }
 }

--- a/manifests/mod/reqtimeout.pp
+++ b/manifests/mod/reqtimeout.pp
@@ -1,8 +1,9 @@
 class apache::mod::reqtimeout {
   apache::mod { 'reqtimeout': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/reqtimeout.conf":
+  file { 'reqtimeout.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/reqtimeout.conf",
     content => template('apache/mod/reqtimeout.conf.erb'),
   }
 }

--- a/manifests/mod/setenvif.pp
+++ b/manifests/mod/setenvif.pp
@@ -1,8 +1,9 @@
 class apache::mod::setenvif {
   apache::mod { 'setenvif': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/setenvif.conf":
+  file { 'setenvif.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/setenvif.conf",
     content => template('apache/mod/setenvif.conf.erb'),
   }
 }

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -12,8 +12,9 @@ class apache::mod::ssl (
   apache::mod { 'ssl': }
 
   # Template uses $ssl_compression, $session_cache, $ssl_mutex
-  file { "${apache::params::mod_dir}/ssl.conf":
+  file { 'ssl.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/ssl.conf",
     content => template('apache/mod/ssl.conf.erb'),
   }
 }

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -1,8 +1,9 @@
 class apache::mod::status {
   apache::mod { 'status': }
   # Template uses no variables
-  file { "${apache::params::mod_dir}/status.conf":
+  file { 'status.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/status.conf",
     content => template('apache/mod/status.conf.erb'),
   }
 }

--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -6,8 +6,9 @@ class apache::mod::userdir (
   apache::mod { 'userdir': }
 
   # Template uses $home, $dir, $disable_root
-  file { "${apache::params::mod_dir}/userdir.conf":
+  file { 'userdir.conf':
     ensure  => present,
+    path    => "${apache::mod_dir}/userdir.conf",
     content => template('apache/mod/userdir.conf.erb'),
   }
 }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -94,7 +94,9 @@ define apache::vhost(
     $block              = [],
     $ensure             = 'present'
   ) {
-  include apache
+  if ! defined(Class['apache']) {
+    fail("You must include the apache base class before using any apache defined resources")
+  }
   $apache_name = $apache::params::apache_name
 
   validate_re($ensure, '^(present|absent)$',
@@ -285,7 +287,7 @@ define apache::vhost(
   #   - $ssl_crl_path
   file { "${priority_real}-${name}.conf":
     ensure  => $ensure,
-    path    => "${apache::params::vhost_dir}/${priority_real}-${name}.conf",
+    path    => "${apache::vhost_dir}/${priority_real}-${name}.conf",
     content => template('apache/vhost.conf.erb'),
     owner   => 'root',
     group   => 'root',

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -94,6 +94,7 @@ define apache::vhost(
     $block              = [],
     $ensure             = 'present'
   ) {
+  # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['apache']) {
     fail("You must include the apache base class before using any apache defined resources")
   }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -66,6 +66,46 @@ describe 'apache', :type => :class do
         'notify'  => 'Service[httpd]',
         'require' => 'Package[httpd]'
       ) }
+
+      # Assert that load files are placed for these mods, but no conf file.
+      [
+        'auth_basic',
+        'authn_file',
+        'authz_default',
+        'authz_groupfile',
+        'authz_host',
+        'authz_user',
+        'dav',
+        'env',
+      ].each do |modname|
+        it { should contain_file("#{modname}.load").with_path(
+          "/etc/httpd/conf.d/#{modname}.load"
+        ) }
+        it { should_not contain_file("#{modname}.conf").with_path(
+          "/etc/httpd/conf.d/#{modname}.conf"
+        ) }
+      end
+
+      # Assert that both load files and conf files are placed for these mods
+      [
+        'alias',
+        'autoindex',
+        'dav_fs',
+        'deflate',
+        'dir',
+        'mime',
+        'negotiation',
+        'setenvif',
+        'status',
+      ].each do |modname|
+        it { should contain_file("#{modname}.load").with_path(
+          "/etc/httpd/conf.d/#{modname}.load"
+        ) }
+        it { should contain_file("#{modname}.conf").with_path(
+          "/etc/httpd/conf.d/#{modname}.conf"
+        ) }
+      end
+
       it { should_not contain_file("/etc/httpd/site.d") }
       it { should_not contain_file("/etc/httpd/mod.d") }
       it { should contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^Include /etc/httpd/conf\.d/\*\.conf$} }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -50,5 +50,41 @@ describe 'apache', :type => :class do
       'require' => 'Package[httpd]'
       )
     }
+    describe "Alternate confd/mod/vhosts directory" do
+      let :params do
+        {
+          :vhost_dir => '/etc/httpd/conf.d',
+          :confd_dir => '/etc/httpd/conf.d',
+          :mod_dir   => '/etc/httpd/conf.d',
+        }
+      end
+
+      it { should contain_file("/etc/httpd/conf.d").with(
+        'ensure'  => 'directory',
+        'recurse' => 'true',
+        'purge'   => 'true',
+        'notify'  => 'Service[httpd]',
+        'require' => 'Package[httpd]'
+      ) }
+      it { should_not contain_file("/etc/httpd/site.d") }
+      it { should_not contain_file("/etc/httpd/mod.d") }
+      it { should contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^Include /etc/httpd/conf\.d/\*\.conf$} }
+      it { should contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^Include /etc/httpd/conf\.d/\*\.load$} }
+    end
+
+    describe "Alternate conf.d directory" do
+      let :params do
+        { :confd_dir => '/etc/httpd/special_conf.d' }
+      end
+
+      it { should contain_file("/etc/httpd/special_conf.d").with(
+        'ensure'  => 'directory',
+        'recurse' => 'true',
+        'purge'   => 'true',
+        'notify'  => 'Service[httpd]',
+        'require' => 'Package[httpd]'
+      ) }
+      it { should_not contain_file("/etc/httpd/conf.d") }
+    end
   end
 end

--- a/spec/classes/mod/auth_kerb_spec.rb
+++ b/spec/classes/mod/auth_kerb_spec.rb
@@ -1,4 +1,7 @@
 describe 'apache::mod::auth_kerb', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
   context "on a Debian OS" do
     let :facts do
       {

--- a/spec/classes/mod/dev_spec.rb
+++ b/spec/classes/mod/dev_spec.rb
@@ -1,4 +1,7 @@
 describe 'apache::dev', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
   context "on a Debian OS" do
     let :facts do
       {

--- a/spec/classes/mod/fcgid_spec.rb
+++ b/spec/classes/mod/fcgid_spec.rb
@@ -1,4 +1,7 @@
 describe 'apache::mod::fcgid', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
   context "on a Debian OS" do
     let :facts do
       {

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -1,4 +1,7 @@
 describe 'apache::mod::passenger', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
   context "on a Debian OS" do
     let :facts do
       {

--- a/spec/classes/mod/perl_spec.rb
+++ b/spec/classes/mod/perl_spec.rb
@@ -1,4 +1,7 @@
 describe 'apache::mod::perl', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
   context "on a Debian OS" do
     let :facts do
       {

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -1,4 +1,7 @@
 describe 'apache::mod::php', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
   context "on a Debian OS" do
     let :facts do
       {

--- a/spec/classes/mod/proxy_html_spec.rb
+++ b/spec/classes/mod/proxy_html_spec.rb
@@ -1,6 +1,7 @@
 describe 'apache::mod::proxy_html', :type => :class do
   let :pre_condition do
     [
+      'include apache',
       'include apache::mod::proxy',
       'include apache::mod::proxy_http',
     ]

--- a/spec/classes/mod/python_spec.rb
+++ b/spec/classes/mod/python_spec.rb
@@ -1,4 +1,7 @@
 describe 'apache::mod::python', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
   context "on a Debian OS" do
     let :facts do
       {

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -1,4 +1,7 @@
 describe 'apache::mod::ssl', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
   context 'on an unsupported OS' do
     let :facts do
       {

--- a/spec/classes/mod/wsgi_spec.rb
+++ b/spec/classes/mod/wsgi_spec.rb
@@ -1,4 +1,7 @@
 describe 'apache::mod::wsgi', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
   context "on a Debian OS" do
     let :facts do
       {

--- a/spec/defines/mod_spec.rb
+++ b/spec/defines/mod_spec.rb
@@ -1,11 +1,15 @@
 require 'spec_helper'
 
 describe 'apache::mod', :type => :define do
+  let :pre_condition do
+    'include apache'
+  end
   context "on a RedHat osfamily" do
     let :facts do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
       }
     end
 
@@ -40,6 +44,7 @@ describe 'apache::mod', :type => :define do
       {
         :osfamily               => 'Debian',
         :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
       }
     end
 


### PR DESCRIPTION
The conf.d/vhost/mod directory layouts are vastly different on Debian and RedHat machines and the refactor makes some assumptions about how we can force the layout, but this should be configurable.

This PR makes the vhost/conf.d/mod directories configurable instead of hardcoded.
