### PR TITLE
Add setenv/setenvif to apache::vhost

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -88,6 +88,8 @@ define apache::vhost(
     $rewrite_rule       = undef,
     $rewrite_base       = undef,
     $rewrite_cond       = undef,
+    $setenv             = [],
+    $setenvif           = [],
     $block              = [],
     $ensure             = 'present'
   ) {
@@ -258,6 +260,9 @@ define apache::vhost(
   #   - $ssl
   # serveralias fragment:
   #   - $serveraliases
+  # setenv fragment:
+  #   - $setenv
+  #   - $setenvif
   # ssl fragment:
   #   - $ssl
   #   - $ssl_cert

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -102,6 +102,21 @@ describe 'apache::vhost', :type => :define do
           :match => ['  ServerAlias one.com','  ServerAlias two.com'],
         },
         {
+          :title => 'should accept setenv',
+          :attr  => 'setenv',
+          :value => ['TEST1 one','TEST2 two'],
+          :match => ['  SetEnv TEST1 one','  SetEnv TEST2 two'],
+        },
+        {
+          :title => 'should accept setenvif',
+          :attr  => 'setenvif',
+          ## These are bugged in rspec-puppet; the $1 is droped
+          #:value => ['Host "^([^\.]*)\.website\.com$" CLIENT_NAME=$1'],
+          #:match => ['  SetEnvIf Host "^([^\.]*)\.website\.com$" CLIENT_NAME=$1'],
+          :value => ['Host "^test\.com$" VHOST_ACCESS=test'],
+          :match => ['  SetEnvIf Host "^test\.com$" VHOST_ACCESS=test'],
+        },
+        {
           :title => 'should accept options',
           :attr  => 'options',
           :value => ['Fake','Options'],

--- a/templates/vhost.conf.erb
+++ b/templates/vhost.conf.erb
@@ -34,5 +34,6 @@
 <%= scope.function_template(['apache/vhost/_rewrite.erb']) -%>
 <%= scope.function_template(['apache/vhost/_scriptalias.erb']) -%>
 <%= scope.function_template(['apache/vhost/_serveralias.erb']) -%>
+<%= scope.function_template(['apache/vhost/_setenv.erb']) -%>
 <%= scope.function_template(['apache/vhost/_ssl.erb']) -%>
 </VirtualHost>

--- a/templates/vhost/_setenv.erb
+++ b/templates/vhost/_setenv.erb
@@ -1,0 +1,12 @@
+<% if @setenv and ! @setenv.empty? -%>
+
+  ## SetEnv/SetEnvIf for environment variables
+<% Array(@setenv).each do |envvar| -%>
+  SetEnv <%= envvar %>
+<% end -%>
+<% end -%>
+<% if @setenvif and ! @setenvif.empty? -%>
+<% Array(@setenvif).each do |envifvar| -%>
+  SetEnvIf <%= envifvar %>
+<% end -%>
+<% end -%>

--- a/tests/vhost.pp
+++ b/tests/vhost.pp
@@ -161,3 +161,15 @@ apache::vhost { 'seventeenth.example.com':
   docroot => '/var/www/seventeenth',
   block   => 'scm',
 }
+
+# Vhost with special environment variables
+apache::vhost { 'eighteenth.example.com':
+  port    => '80',
+  docroot => '/var/www/eighteenth',
+  setenv  => ['SPECIAL_PATH /foo/bin','KILROY was_here'],
+}
+apache::vhost { 'nineteenth.example.com':
+  port     => '80',
+  docroot  => '/var/www/nineteenth',
+  setenvif => 'Host "^([^\.]*)\.website\.com$" CLIENT_NAME=$1',
+}


### PR DESCRIPTION
`SetEnv` is used by httpd to set environment variables for vhosts.
`SetEnvIf` is used to conditionally set environment variables.
