### PR TITLE
Rename apache::mod::default to apache::default_mods

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -1,4 +1,4 @@
-class apache::mod::default {
+class apache::default_mods {
   case $::osfamily {
     'debian': {
       include apache::mod::cgid # Debian uses mpm_worker

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,7 +127,7 @@ class apache (
       require => Package['httpd'],
     }
     if $default_mods {
-      include apache::mod::default
+      include apache::default_mods
     }
     if $default_vhost {
       apache::vhost { 'default':


### PR DESCRIPTION
Similar to `apache::mod::dev` being moved to `apache::dev`,
`apache::mod::default` is not a module itself, just a collection of
httpd modules and so shouldn't exist in the `apache::mod::*` namespace.
