### PR TITLE
Sym link mods

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,8 @@ class apache (
   $error_documents      = false,
   $confd_dir            = $apache::params::confd_dir,
   $vhost_dir            = $apache::params::vhost_dir,
-  $mod_dir              = $apache::params::mod_dir
+  $mod_dir              = $apache::params::mod_dir,
+  $mod_enable_dir       = $apache::params::mod_enable_dir
 ) inherits apache::params {
 
   package { 'httpd':
@@ -65,6 +66,16 @@ class apache (
 
   if ! defined(File[$apache::mod_dir]) {
     file { $apache::mod_dir:
+      ensure  => directory,
+      recurse => true,
+      purge   => $purge_configs,
+      notify  => Service['httpd'],
+      require => Package['httpd'],
+    }
+  }
+
+  if $apache::mod_enable_dir and ! defined(File[$apache::mod_enable_dir]) {
+    file { $apache::mod_enable_dir:
       ensure  => directory,
       recurse => true,
       purge   => $purge_configs,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,7 +139,7 @@ class apache (
     # - $error_documents
     # - $error_documents_path
     file { "${apache::params::conf_dir}/${apache::params::conf_file}":
-      ensure  => present,
+      ensure  => file,
       content => template("apache/httpd.conf.erb"),
       notify  => Service['httpd'],
       require => Package['httpd'],

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -51,8 +51,8 @@ define apache::mod (
   }
 
   if $::osfamily == 'Debian' {
-    $enable_dir = $apache::params::mod_enable_dir
-    file{ "enable.${mod}.load":
+    $enable_dir = $apache::mod_enable_dir
+    file{ "${mod}.load symlink":
       path    => "${enable_dir}/${mod}.load",
       ensure  => link,
       target  => "${mod_dir}/${mod}.load",
@@ -66,7 +66,7 @@ define apache::mod (
     # defined in the class apache::mod::module
     # Some modules do not require this file.
     if defined(File["${mod}.conf"]) {
-      file{ "enable.${mod}.conf":
+      file{ "${mod}.conf symlink":
         path    => "${enable_dir}/${mod}.conf",
         ensure  => link,
         target  => "${mod_dir}/${mod}.conf",

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -49,4 +49,18 @@ define apache::mod (
     require => Package['httpd'],
     notify  => Service['httpd'],
   }
+
+  if $::osfamily == 'Debian' {
+    $enable_dir = $apache::params::mod_enable_dir
+    file{ "enable.${mod}.load":
+      path    => "${enable_dir}/${mod}.load",
+      ensure  => link,
+      target  => "${mod_dir}/${mod}.load",
+      owner   => $apache::params::user,
+      group   => $apache::params::group,
+      mode    => '0644',
+      require => File["${mod}.load"],
+      notify  => Service['httpd'],
+    }
+  }
 }

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -62,5 +62,20 @@ define apache::mod (
       require => File["${mod}.load"],
       notify  => Service['httpd'],
     }
+    # Each module may have a .conf file as well, which should be
+    # defined in the class apache::mod::module
+    # Some modules do not require this file.
+    if defined(File["${mod}.conf"]) {
+      file{ "enable.${mod}.conf":
+        path    => "${enable_dir}/${mod}.conf",
+        ensure  => link,
+        target  => "${mod_dir}/${mod}.conf",
+        owner   => $apache::params::user,
+        group   => $apache::params::group,
+        mode    => '0644',
+        require => File["${mod}.conf"],
+        notify  => Service['httpd'],
+      }
+    }
   }
 }

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -41,7 +41,7 @@ define apache::mod (
 
   file { "${mod}.load":
     path    => "${mod_dir}/${mod}.load",
-    ensure  => present,
+    ensure  => file,
     owner   => $apache::params::user,
     group   => $apache::params::group,
     mode    => '0644',

--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -6,7 +6,7 @@ class apache::mod::alias {
   apache::mod { 'alias': }
   # Template uses $icons_path
   file { 'alias.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/alias.conf",
     content => template('apache/mod/alias.conf.erb'),
   }

--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -2,7 +2,7 @@ class apache::mod::autoindex {
   apache::mod { 'autoindex': }
   # Template uses no variables
   file { 'autoindex.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/autoindex.conf",
     content => template('apache/mod/autoindex.conf.erb'),
   }

--- a/manifests/mod/cgid.pp
+++ b/manifests/mod/cgid.pp
@@ -5,7 +5,7 @@ class apache::mod::cgid {
   apache::mod { 'cgid': }
   # Template uses $cgisock_path
   file { 'cgid.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/cgid.conf",
     content => template('apache/mod/cgid.conf.erb'),
   }

--- a/manifests/mod/dav_fs.pp
+++ b/manifests/mod/dav_fs.pp
@@ -9,7 +9,7 @@ class apache::mod::dav_fs {
 
   # Template uses: $dav_lock
   file { 'dav_fs.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/dav_fs.conf",
     content => template('apache/mod/php.conf.erb'),
   }

--- a/manifests/mod/deflate.pp
+++ b/manifests/mod/deflate.pp
@@ -2,7 +2,7 @@ class apache::mod::deflate {
   apache::mod { 'deflate': }
   # Template uses no variables
   file { 'deflate.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/deflate.conf",
     content => template('apache/mod/deflate.conf.erb'),
   }

--- a/manifests/mod/dir.pp
+++ b/manifests/mod/dir.pp
@@ -5,7 +5,7 @@ class apache::mod::dir (
 
   # Template uses no variables
   file { 'dir.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/dir.conf",
     content => template('apache/mod/dir.conf.erb'),
   }

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -9,7 +9,7 @@ class apache::mod::disk_cache {
   apache::mod { 'disk_cache': }
   # Template uses $cache_proxy
   file { 'disk_cache.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/disk_cache.conf",
     content => template('apache/mod/disk_cache.conf.erb'),
   }

--- a/manifests/mod/info.pp
+++ b/manifests/mod/info.pp
@@ -2,7 +2,7 @@ class apache::mod::info {
   apache::mod { 'info': }
   # Template uses no variables
   file { 'info.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/info.conf",
     content => template('apache/mod/info.conf.erb'),
   }

--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -2,7 +2,7 @@ class apache::mod::ldap {
   apache::mod { 'ldap': }
   # Template uses no variables
   file { 'ldap.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/ldap.conf",
     content => template('apache/mod/ldap.conf.erb'),
   }

--- a/manifests/mod/mime.pp
+++ b/manifests/mod/mime.pp
@@ -2,7 +2,7 @@ class apache::mod::mime {
   apache::mod { 'mime': }
   # Template uses no variables
   file { 'mime.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/mime.conf",
     content => template('apache/mod/mime.conf.erb'),
   }

--- a/manifests/mod/mime_magic.pp
+++ b/manifests/mod/mime_magic.pp
@@ -2,7 +2,7 @@ class apache::mod::mime_magic {
   apache::mod { 'mime_magic': }
   # Template uses no variables
   file { 'mime_magic.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/mime_magic.conf",
     content => template('apache/mod/mime_magic.conf.erb'),
   }

--- a/manifests/mod/mpm_event.pp
+++ b/manifests/mod/mpm_event.pp
@@ -1,7 +1,7 @@
 class apache::mod::mpm_event {
   # Template uses no variables
   file { 'mpm_event.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/mpm_event.conf",
     content => template('apache/mod/mpm_event.conf.erb'),
   }

--- a/manifests/mod/negotiation.pp
+++ b/manifests/mod/negotiation.pp
@@ -2,7 +2,7 @@ class apache::mod::negotiation {
   apache::mod { 'negotiation': }
   # Template uses no variables
   file { 'negotiation.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/negotiation.conf",
     content => template('apache/mod/negotiation.conf.erb'),
   }

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -6,7 +6,7 @@ class apache::mod::passenger (
   apache::mod { 'passenger': }
   # Template uses: $passenger_root, $passenger_ruby, $passenger_max_pool_size
   file { 'passenger.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/passenger.conf",
     content => template('apache/mod/passenger.conf.erb'),
   }

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -4,7 +4,7 @@ class apache::mod::passenger (
   $passenger_max_pool_size = undef,
 ) {
   apache::mod { 'passenger': }
-  # Template uses $passenger_root, $passenger_ruby, $passenger_max_pool_size
+  # Template uses: $passenger_root, $passenger_ruby, $passenger_max_pool_size
   file { 'passenger.conf':
     ensure  => present,
     path    => "${apache::mod_dir}/passenger.conf",

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -1,7 +1,7 @@
 class apache::mod::php {
   apache::mod { 'php5': }
   file { 'php.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/php.conf",
     content => template('apache/mod/php.conf.erb'),
   }

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -4,7 +4,7 @@ class apache::mod::proxy (
   apache::mod { 'proxy': }
   # Template uses $proxy_requests
   file { 'proxy.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/proxy.conf",
     content => template('apache/mod/proxy.conf.erb'),
   }

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -15,7 +15,7 @@ class apache::mod::proxy_html {
   }
   # Template uses $icons_path
   file { 'proxy_html.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/proxy_html.conf",
     content => template('apache/mod/proxy_html.conf.erb'),
   }

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -8,4 +8,18 @@ class apache::mod::proxy_html {
     path    => "${apache::mod_dir}/libxml2.conf",
     content => "LoadFile /usr/lib/libxml2.so.2\n",
   }
+  # ...that Debian thing!
+  if $::osfamily == 'Debian' {
+    $enable_dir = $apache::params::mod_enable_dir
+    file{ "enable.libxml2.load":
+      path    => "${enable_dir}/libxml2.load",
+      ensure  => link,
+      target  => "${mod_dir}/libxml2.load",
+      owner   => $apache::params::user,
+      group   => $apache::params::group,
+      mode    => '0644',
+      require => File["libxml2.load"],
+      notify  => Service['httpd'],
+    }
+  }
 }

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -2,24 +2,21 @@ class apache::mod::proxy_html {
   Class['apache::mod::proxy'] -> Class['apache::mod::proxy_html']
   Class['apache::mod::proxy_http'] -> Class['apache::mod::proxy_html']
   apache::mod { 'proxy_html': }
-  # proxy_html uses libxml2 so we need to load this .so
-  file { 'libxml2.load':
-    ensure  => present,
-    path    => "${apache::mod_dir}/libxml2.conf",
-    content => "LoadFile /usr/lib/libxml2.so.2\n",
-  }
-  # ...that Debian thing!
-  if $::osfamily == 'Debian' {
-    $enable_dir = $apache::params::mod_enable_dir
-    file{ "enable.libxml2.load":
-      path    => "${enable_dir}/libxml2.load",
-      ensure  => link,
-      target  => "${mod_dir}/libxml2.load",
-      owner   => $apache::params::user,
-      group   => $apache::params::group,
-      mode    => '0644',
-      require => File["libxml2.load"],
-      notify  => Service['httpd'],
+  case $::osfamily {
+    'RedHat': {
+      apache::mod { 'xml2enc': }
     }
+    'Debian': {
+      $proxy_html_loadfiles = $apache::params::distrelease ? {
+        '6'     => '/usr/lib/libxml2.so.2',
+        default => "/usr/lib/${::hardwaremodel}-linux-gnu/libxml2.so.2",
+      }
+    }
+  }
+  # Template uses $icons_path
+  file { 'proxy_html.conf':
+    ensure  => present,
+    path    => "${apache::mod_dir}/proxy_html.conf",
+    content => template('apache/mod/proxy_html.conf.erb'),
   }
 }

--- a/manifests/mod/reqtimeout.pp
+++ b/manifests/mod/reqtimeout.pp
@@ -2,7 +2,7 @@ class apache::mod::reqtimeout {
   apache::mod { 'reqtimeout': }
   # Template uses no variables
   file { 'reqtimeout.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/reqtimeout.conf",
     content => template('apache/mod/reqtimeout.conf.erb'),
   }

--- a/manifests/mod/setenvif.pp
+++ b/manifests/mod/setenvif.pp
@@ -2,7 +2,7 @@ class apache::mod::setenvif {
   apache::mod { 'setenvif': }
   # Template uses no variables
   file { 'setenvif.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/setenvif.conf",
     content => template('apache/mod/setenvif.conf.erb'),
   }

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -13,7 +13,7 @@ class apache::mod::ssl (
 
   # Template uses $ssl_compression, $session_cache, $ssl_mutex
   file { 'ssl.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/ssl.conf",
     content => template('apache/mod/ssl.conf.erb'),
   }

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -2,7 +2,7 @@ class apache::mod::status {
   apache::mod { 'status': }
   # Template uses no variables
   file { 'status.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/status.conf",
     content => template('apache/mod/status.conf.erb'),
   }

--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -7,7 +7,7 @@ class apache::mod::userdir (
 
   # Template uses $home, $dir, $disable_root
   file { 'userdir.conf':
-    ensure  => present,
+    ensure  => file,
     path    => "${apache::mod_dir}/userdir.conf",
     content => template('apache/mod/userdir.conf.erb'),
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,8 @@ class apache::params {
     $httpd_dir        = '/etc/apache2'
     $conf_dir         = "${httpd_dir}"
     $confd_dir        = "${httpd_dir}/conf.d"
-    $mod_dir          = "${httpd_dir}/mods-enabled"
+    $mod_dir          = "${httpd_dir}/mods-available"
+    $mod_enable_dir   = "${httpd_dir}/mods-enabled"
     $vhost_dir        = "${httpd_dir}/sites-enabled"
     $conf_file        = 'apache2.conf'
     $ports_file       = "${conf_dir}/ports.conf"

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -25,6 +25,77 @@ describe 'apache', :type => :class do
       'require' => 'Package[httpd]'
       )
     }
+    it { should contain_file("/etc/apache2/mods-enabled").with(
+      'ensure'  => 'directory',
+      'recurse' => 'true',
+      'purge'   => 'true',
+      'notify'  => 'Service[httpd]',
+      'require' => 'Package[httpd]'
+      )
+    }
+    it { should contain_file("/etc/apache2/mods-available").with(
+      'ensure'  => 'directory',
+      'recurse' => 'true',
+      'purge'   => 'true',
+      'notify'  => 'Service[httpd]',
+      'require' => 'Package[httpd]'
+      )
+    }
+    # Assert that load files are placed and symlinked for these mods, but no conf file.
+    [
+      'auth_basic',
+      'authn_file',
+      'authz_default',
+      'authz_groupfile',
+      'authz_host',
+      'authz_user',
+      'dav',
+      'env',
+    ].each do |modname|
+      it { should contain_file("#{modname}.load").with(
+        'path'   => "/etc/apache2/mods-available/#{modname}.load",
+        'ensure' => 'file',
+      ) }
+      it { should contain_file("#{modname}.load symlink").with(
+        'path'   => "/etc/apache2/mods-enabled/#{modname}.load",
+        'ensure' => 'link',
+        'target' => "/etc/apache2/mods-available/#{modname}.load"
+      ) }
+      it { should_not contain_file("#{modname}.conf") }
+      it { should_not contain_file("#{modname}.conf symlink") }
+    end
+
+    # Assert that both load files and conf files are placed and symlinked for these mods
+    [
+      'alias',
+      'autoindex',
+      'dav_fs',
+      'deflate',
+      'dir',
+      'mime',
+      'negotiation',
+      'setenvif',
+      'status',
+    ].each do |modname|
+      it { should contain_file("#{modname}.load").with(
+        'path'   => "/etc/apache2/mods-available/#{modname}.load",
+        'ensure' => 'file',
+      ) }
+      it { should contain_file("#{modname}.load symlink").with(
+        'path'   => "/etc/apache2/mods-enabled/#{modname}.load",
+        'ensure' => 'link',
+        'target' => "/etc/apache2/mods-available/#{modname}.load"
+      ) }
+      it { should contain_file("#{modname}.conf").with(
+        'path'   => "/etc/apache2/mods-available/#{modname}.conf",
+        'ensure' => 'file',
+      ) }
+      it { should contain_file("#{modname}.conf symlink").with(
+        'path'   => "/etc/apache2/mods-enabled/#{modname}.conf",
+        'ensure' => 'link',
+        'target' => "/etc/apache2/mods-available/#{modname}.conf"
+      ) }
+    end
   end
   context "on a RedHat 5 OS" do
     let :facts do

--- a/spec/defines/mod_spec.rb
+++ b/spec/defines/mod_spec.rb
@@ -55,8 +55,14 @@ describe 'apache::mod', :type => :define do
       it { should include_class("apache::params") }
       it "should manage the module load file" do
         should contain_file('spec_m.load').with({
-          :path    => '/etc/apache2/mods-enabled/spec_m.load',
+          :path    => '/etc/apache2/mods-available/spec_m.load',
           :content => "LoadModule spec_m_module /usr/lib/apache2/modules/mod_spec_m.so\n"
+        } )
+      end
+      it "should link the module load file" do
+        should contain_file('spec_m.load symlink').with({
+          :path   => '/etc/apache2/mods-enabled/spec_m.load',
+          :target => '/etc/apache2/mods-available/spec_m.load',
         } )
       end
     end

--- a/templates/mod/proxy_html.conf.erb
+++ b/templates/mod/proxy_html.conf.erb
@@ -1,0 +1,24 @@
+<% if @proxy_html_loadfiles -%>
+<% Array(@proxy_html_loadfiles).each do |loadfile| -%>
+LoadFile <%= loadfile %>
+<% end -%>
+
+<% end -%>
+ProxyHTMLLinks  a               href
+ProxyHTMLLinks  area            href
+ProxyHTMLLinks  link            href
+ProxyHTMLLinks  img             src longdesc usemap
+ProxyHTMLLinks  object          classid codebase data usemap
+ProxyHTMLLinks  q               cite
+ProxyHTMLLinks  blockquote      cite
+ProxyHTMLLinks  ins             cite
+ProxyHTMLLinks  del             cite
+ProxyHTMLLinks  form            action
+ProxyHTMLLinks  input           src usemap
+ProxyHTMLLinks  head            profileProxyHTMLLinks  base            href
+ProxyHTMLLinks  script          src for
+
+ProxyHTMLEvents onclick ondblclick onmousedown onmouseup \
+                onmouseover onmousemove onmouseout onkeypress \
+                onkeydown onkeyup onfocus onblur onload \
+                onunload onsubmit onreset onselect onchange


### PR DESCRIPTION
This PR includes commits from #13 from @Aethylred because of puppetlabs/#160.

It also includes a few additions:
- Spec tests and modifications to meet specs
- Changing the name of the symlink titles from `enable.${mod}.load` to `${mod}.load symlink`
- Management of `mods-available` directory on Debian OS families
- Addition of `apache::mod::proxy_html` template (was absent) and tried to clean up the libxml2 loading.
