### PR TITLE
Control server-info location

### DIFF
--- a/manifests/mod/info.pp
+++ b/manifests/mod/info.pp
@@ -1,9 +1,14 @@
-class apache::mod::info {
+class apache::mod::info (
+  $enable     = false,
+  $allow_from = ['127.0.0.1','::1'],
+){
   apache::mod { 'info': }
-  # Template uses no variables
-  file { 'info.conf':
-    ensure  => present,
-    path    => "${apache::mod_dir}/info.conf",
-    content => template('apache/mod/info.conf.erb'),
+  # Template uses $allow_from
+  if $enable {
+    file { 'info.conf':
+      ensure  => present,
+      path    => "${apache::mod_dir}/info.conf",
+      content => template('apache/mod/info.conf.erb'),
+    }
   }
 }

--- a/manifests/mod/info.pp
+++ b/manifests/mod/info.pp
@@ -1,14 +1,11 @@
 class apache::mod::info (
-  $enable     = false,
   $allow_from = ['127.0.0.1','::1'],
 ){
   apache::mod { 'info': }
   # Template uses $allow_from
-  if $enable {
-    file { 'info.conf':
-      ensure  => present,
-      path    => "${apache::mod_dir}/info.conf",
-      content => template('apache/mod/info.conf.erb'),
-    }
+  file { 'info.conf':
+    ensure  => present,
+    path    => "${apache::mod_dir}/info.conf",
+    content => template('apache/mod/info.conf.erb'),
   }
 }

--- a/templates/mod/info.conf.erb
+++ b/templates/mod/info.conf.erb
@@ -2,5 +2,5 @@
     SetHandler server-info
     Order deny,allow
     Deny from all
-    Allow from 127.0.0.1 ::1
+    Allow from <%= Array(@allow_from).join(" ") %>
 </Location>


### PR DESCRIPTION
This commit enhances the control over the server-info location. It
includes the ability to enable/disable it, as well as controll the
allow list.
