### PR TITLE
Add custom vhost content parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ Specifies the list of things Apache will block access to. The default is an empt
 
 Specifies whether a firewall should be configured. Valid values are 'true' or 'false'.
 
+#####`content`
+
+Specifies alternative vhost configuration content. Valid values are strings.
+
 #####`default_vhost`
 
 Sets a given `apache::vhost` as the default to serve requests that do not match any other `apache::vhost` definitions. The default value is 'false'.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -94,6 +94,7 @@ define apache::vhost(
     $setenv             = [],
     $setenvif           = [],
     $block              = [],
+    $content            = '',
     $ensure             = 'present'
   ) {
   # The base class must be included first because it is used by parameter defaults
@@ -110,6 +111,7 @@ define apache::vhost(
   validate_bool($access_log)
   validate_bool($ssl)
   validate_bool($default_vhost)
+  validate_string($content)
 
   if $ssl {
     include apache::mod::ssl
@@ -299,10 +301,16 @@ define apache::vhost(
   #   - $ssl_ca
   #   - $ssl_crl
   #   - $ssl_crl_path
+  if $content {
+    $vhost_content = $content
+  } else {
+    $vhost_content = template('apache/vhost.conf.erb')
+  }
+
   file { "${priority_real}-${name}.conf":
     ensure  => $ensure,
     path    => "${apache::vhost_dir}/${priority_real}-${name}.conf",
-    content => template('apache/vhost.conf.erb'),
+    content => $vhost_content,
     owner   => 'root',
     group   => 'root',
     mode    => '0755',

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -51,7 +51,7 @@
 #  }
 #
 define apache::vhost(
-    $docroot,
+    $docroot            = undef,
     $port               = undef,
     $ip                 = undef,
     $ip_based           = false,
@@ -115,25 +115,6 @@ define apache::vhost(
 
   if $ssl {
     include apache::mod::ssl
-  }
-
-  # This ensures that the docroot exists
-  # But enables it to be specified across multiple vhost resources
-  if ! defined(File[$docroot]) {
-    file { $docroot:
-      ensure  => directory,
-      owner   => $docroot_owner,
-      group   => $docroot_group,
-      require => Package['httpd'],
-    }
-  }
-
-  # Same as above, but for logroot
-  if ! defined(File[$logroot]) {
-    file { $logroot:
-      ensure  => directory,
-      require => Package['httpd'],
-    }
   }
 
   # Open listening ports if they are not already
@@ -233,6 +214,28 @@ define apache::vhost(
     $priority_real = '10'
   } else {
     $priority_real = '25'
+  }
+
+  if $docroot {
+    # This ensures that the docroot exists
+    # But enables it to be specified across multiple vhost resources
+    if ! defined(File[$docroot]) {
+      file { $docroot:
+        ensure  => directory,
+        owner   => $docroot_owner,
+        group   => $docroot_group,
+        require => Package['httpd'],
+        before  => File["${priority_real}-${name}.conf"],
+      }
+    }
+  }
+
+  # Same as above, but for logroot
+  if ! defined(File[$logroot]) {
+    file { $logroot:
+      ensure  => directory,
+      require => Package['httpd'],
+    }
   }
 
   # Configure firewall rules

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -184,6 +184,13 @@ describe 'apache::vhost', :type => :define do
           :match => '  RewriteRule not a real rule',
         },
         {
+          :title    => 'should accept custom content',
+          :attr     => 'content',
+          :value    => 'not a real vhost config',
+          :match    => 'not a real vhost config',
+          :notmatch => '</VirtualHost>',
+        },
+        {
           :title => 'should block scm',
           :attr  => 'block',
           :value => 'scm',

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -9,7 +9,6 @@ describe 'apache::vhost', :type => :define do
   end
   let :default_params do
     {
-      :docroot => '/rspec/docroot',
       :port    => '84',
     }
   end
@@ -212,6 +211,7 @@ describe 'apache::vhost', :type => :define do
     context 'attribute resources' do
       describe 'when docroot owner is specified' do
         let :params do default_params.merge({
+          :docroot       => '/rspec/docroot',
           :docroot_owner => 'testuser',
           :docroot_group => 'testgroup',
         }) end


### PR DESCRIPTION
This PR adds a `content` parameter which can sidestep most client vhost requirements that are not supported until they can be coded and merged.
