### PR TITLE
Add default configure_firewall parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ The default certificate revocation list path, which is automatically set to 'und
 
 The default certificate revocation list to use, which is automatically set to 'undef'. This default will work out of the box but must be updated with your specific certificate information before being used in production.
 
+#####`default_configure_firewall`
+
+The default setting whether a firewall should be configured. Valid values are 'true' or 'false'. Defaults to 'true'.
+
 #####`service_enable`
 
 Determines whether the 'httpd' service is enabled when the machine is booted, meaning Puppet will check the service status to start/stop it. Defaults to 'true', meaning the service is enabled/running.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,24 +13,25 @@
 # Sample Usage:
 #
 class apache (
-  $default_mods         = true,
-  $default_vhost        = true,
-  $default_ssl_vhost    = false,
-  $default_ssl_cert     = $apache::params::default_ssl_cert,
-  $default_ssl_key      = $apache::params::default_ssl_key,
-  $default_ssl_chain    = undef,
-  $default_ssl_ca       = undef,
-  $default_ssl_crl_path = undef,
-  $default_ssl_crl      = undef,
-  $service_enable       = true,
-  $purge_configs        = true,
-  $serveradmin          = 'root@localhost',
-  $sendfile             = false,
-  $error_documents      = false,
-  $confd_dir            = $apache::params::confd_dir,
-  $vhost_dir            = $apache::params::vhost_dir,
-  $mod_dir              = $apache::params::mod_dir,
-  $mod_enable_dir       = $apache::params::mod_enable_dir
+  $default_mods               = true,
+  $default_vhost              = true,
+  $default_ssl_vhost          = false,
+  $default_ssl_cert           = $apache::params::default_ssl_cert,
+  $default_ssl_key            = $apache::params::default_ssl_key,
+  $default_ssl_chain          = undef,
+  $default_ssl_ca             = undef,
+  $default_ssl_crl_path       = undef,
+  $default_ssl_crl            = undef,
+  $default_configure_firewall = true,
+  $service_enable             = true,
+  $purge_configs              = true,
+  $serveradmin                = 'root@localhost',
+  $sendfile                   = false,
+  $error_documents            = false,
+  $confd_dir                  = $apache::params::confd_dir,
+  $vhost_dir                  = $apache::params::vhost_dir,
+  $mod_dir                    = $apache::params::mod_dir,
+  $mod_enable_dir             = $apache::params::mod_enable_dir
 ) inherits apache::params {
 
   package { 'httpd':

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -59,7 +59,7 @@ define apache::vhost(
     $docroot_owner      = 'root',
     $docroot_group      = 'root',
     $serveradmin        = false,
-    $configure_firewall = true,
+    $configure_firewall = $apache::default_configure_firewall,
     $ssl                = false,
     $ssl_cert           = $apache::default_ssl_cert,
     $ssl_key            = $apache::default_ssl_key,

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -105,6 +105,18 @@ describe 'apache', :type => :class do
         'target' => "/etc/apache2/mods-available/#{modname}.conf"
       ) }
     end
+    describe "firewall configuration disabled" do
+      let :params do
+        { :default_configure_firewall => false }
+      end
+      it { should contain_apache__vhost('default').with('configure_firewall' => false) }
+    end
+    describe "firewall configuration enabled" do
+      let :params do
+        { :default_configure_firewall => true }
+      end
+      it { should contain_apache__vhost('default').with('configure_firewall' => true) }
+    end
   end
   context "on a RedHat 5 OS" do
     let :facts do


### PR DESCRIPTION
This patch allows to set the default value of the `configure_firewall` parameter for vhosts by introducing a `default_configure_firewall` parameter for the apache class.
