### PR TITLE
Change default RedHat confdir

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,8 +32,8 @@ class apache::params {
     $httpd_dir            = '/etc/httpd'
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
-    $mod_dir              = "${httpd_dir}/mod.d"
-    $vhost_dir            = "${httpd_dir}/site.d"
+    $mod_dir              = "${httpd_dir}/conf.d"
+    $vhost_dir            = "${httpd_dir}/conf.d"
     $conf_file            = 'httpd.conf'
     $ports_file           = "${conf_dir}/ports.conf"
     $logroot              = '/var/log/httpd'

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -26,7 +26,7 @@ describe 'apache::mod::prefork', :type => :class do
     end
     it { should include_class("apache::params") }
     it { should_not contain_apache__mod('prefork') }
-    it { should contain_file("/etc/httpd/mod.d/prefork.conf").with_ensure('file') }
+    it { should contain_file("/etc/httpd/conf.d/prefork.conf").with_ensure('file') }
     it { should contain_file_line("/etc/sysconfig/httpd prefork enable") }
   end
 end

--- a/spec/classes/mod/worker_spec.rb
+++ b/spec/classes/mod/worker_spec.rb
@@ -26,7 +26,7 @@ describe 'apache::mod::worker', :type => :class do
     end
     it { should include_class("apache::params") }
     it { should_not contain_apache__mod('worker') }
-    it { should contain_file("/etc/httpd/mod.d/worker.conf").with_ensure('file') }
+    it { should contain_file("/etc/httpd/conf.d/worker.conf").with_ensure('file') }
     it { should contain_file_line("/etc/sysconfig/httpd worker enable") }
   end
 end

--- a/spec/defines/mod_spec.rb
+++ b/spec/defines/mod_spec.rb
@@ -20,7 +20,7 @@ describe 'apache::mod', :type => :define do
       it { should include_class("apache::params") }
       it "should manage the module load file" do
         should contain_file('spec_m.load').with({
-          :path    => '/etc/httpd/mod.d/spec_m.load',
+          :path    => '/etc/httpd/conf.d/spec_m.load',
           :content => "LoadModule spec_m_module modules/mod_spec_m.so\n",
           :owner   => 'root',
           :group   => 'root',

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -35,7 +35,9 @@ EnableSendfile <%= @sendfile %>
 
 #Listen 80
 Include <%= @mod_dir %>/*.load
+<% if @mod_dir != @confd_dir and @mod_dir != @vhost_dir -%>
 Include <%= @mod_dir %>/*.conf
+<% end -%>
 Include <%= @ports_file %>
 
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
@@ -44,7 +46,9 @@ LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 
 Include <%= @confd_dir %>/*.conf
+<% if @vhost_dir != @confd_dir -%>
 Include <%= @vhost_dir %>/*.conf
+<% end -%>
 
 <% if @error_documents -%>
 # /usr/share/apache2/error on debian


### PR DESCRIPTION
RedHat sticks all mods/confs/vhosts in `$confdir/conf.d` but Debian sticks them in separate directories. Previosly the Apache module simulated Debian style conf dirs on RedHat, but this leads to confusing purging and updating with respect to configs that are added to `conf.d` by packages.

Changing the default to `conf.d` means that configs placed by packages are updated rather than ignored or purged. Also if purging is turned off this will not cause undesired config declarations.
